### PR TITLE
Handle comments that contain only cross-references

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -164,17 +164,17 @@ def preprocess(comment, section_nr, preserve_paths=True, outdir=None):
         # Check if the match contains an anchor
         if '#' in match.group(1):
             name, anchor = match.group(1).split('#')
-            return " [%s](%s#%s)" % (name,
-                                     path.basename(destination(name,
-                                                               preserve_paths=preserve_paths,
-                                                               outdir=outdir)),
-                                     anchor)
+            return "[%s](%s#%s)" % (name,
+                                    path.basename(destination(name,
+                                                              preserve_paths=preserve_paths,
+                                                              outdir=outdir)),
+                                    anchor)
 
         else:
-            return " [%s](%s)" % (match.group(1),
-                                  path.basename(destination(match.group(1),
-                                                            preserve_paths=preserve_paths,
-                                                            outdir=outdir)))
+            return "[%s](%s)" % (match.group(1),
+                                 path.basename(destination(match.group(1),
+                                                           preserve_paths=preserve_paths,
+                                                           outdir=outdir)))
 
     def replace_section_name(match):
         return '%(lvl)s <span id="%(id)s" href="%(id)s">%(name)s</span>' % {
@@ -184,7 +184,7 @@ def preprocess(comment, section_nr, preserve_paths=True, outdir=None):
         }
 
     comment = re.sub('^([=]+)([^=]+)[=]*\s*$', replace_section_name, comment)
-    comment = re.sub('[^`]\[\[(.+?)\]\]', replace_crossref, comment)
+    comment = re.sub('(?<!`)\[\[(.+?)\]\]', replace_crossref, comment)
 
     return comment
 

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -172,7 +172,6 @@ def preprocess(comment, preserve_paths=True, outdir=None):
         # Check if the match contains an anchor
         if '#' in match.group(1):
             name, anchor = match.group(1).split('#')
-
             return " [{}]({}#{})".format(name,
                                          path.basename(destination(name,
                                                                    preserve_paths=preserve_paths,

--- a/tests/test_pycco.py
+++ b/tests/test_pycco.py
@@ -60,6 +60,13 @@ def test_multi_line_leading_spaces():
     assert parsed[0]["docs_text"] == "This is a\ncomment that\nis indented\n"
 
 
+def test_comment_with_only_cross_ref():
+    source = '''# ==Link Target==\n\ndef test_link():\n    """[[testing.py#link-target]]"""\n    pass'''
+    sections = p.parse(source, PYTHON)
+    p.highlight(sections, PYTHON, outdir=tempfile.gettempdir())
+    assert sections[1]['docs_html']  == '<p><a href="testing.html#link-target">testing.py</a></p>'
+
+
 @given(text(), text())
 def test_get_language_specify_language(source, code):
     assert p.get_language(source, code, language="python") == p.languages['.py']


### PR DESCRIPTION
Fixes #81 using a negative lookbehind to check for backticks