### PR TITLE
Multi-Line Comment Bugfix for Issue #17

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -360,8 +360,6 @@ def get_language(source, code, language=None):
         lang = lexers.guess_lexer(code).name.lower()
         for l in languages.values():
             if l["name"] == lang:
-                print "First Delimiters"
-                print l.multi_line_delimiters
                 return l
         else:
             raise ValueError("Can't figure out the language!")


### PR DESCRIPTION
Below I've created support to fix the bug documented in Issue #17. Previously, mulit-line comments that were opened but were not the beginning of the line were not detected. Under the current version of pycco, the code below became very obfuscated when documentation was generated.

# ## The Bug

# does this render on the left or right?
print smushed(2, 5)==4


p = """
how about this?
"""

y = z  # is this where it should be?

# how did this get so *BIG!*

def x3():
    """how would you fix?
    """


However, with this fix, the "p = " section is handled appropriately.